### PR TITLE
CAFE-22 Allow injectContent to accept a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function MyApp () {
 export default MyApp;
 ```
 
-Then inject a `content` prop into your components using the higher order component:
+Then inject a `content` prop into your components using the `injectContent` higher order component:
 ```js
 // ./MyPage
 import React from 'react';
@@ -65,6 +65,55 @@ export default injectContent('helloWorld')(MyPage);
 ```
 
 The `content` prop is an object with keys corresponding to each requested slug.
+
+You can provide `injectContent` with any number of arguments for each slug you want to retrieve
+
+```js
+// ./MyPage
+import React from 'react';
+import {injectContent} from '@trioxis/react-cafe-cms';
+
+function MyPage (props) {
+  const {content} = props
+  return (
+    <div>
+      <p>{content.helloWorld}</p>
+      <p>{content.seasonalOffer}</p>
+    </div>
+  );
+}
+
+export default injectContent('helloWorld', 'seasonalOffer')(MyPage);
+```
+
+You can provide `injectContent` with a single function that recieves props and returns an array of slugs  to retrieve. Use this to dynamically figure out the slugs based on props.
+
+```js
+import React from 'react';
+import {injectContent} from '@trioxis/react-cafe-cms';
+
+function offerBox (props) {
+  const {type, content} = props;
+  return (
+    <div>
+      <h1>{content.offerTitle}</h1>
+      <p>{content[type]}</p>
+    </div>
+  )
+}
+
+const MyOffer = injectContent(
+  props => ['offerTitle', props.type]
+)(offerBox);
+
+function MyPage (props) {
+  return (
+    <MyOffer type="seasonal" />
+  );
+}
+
+export default MyPage;
+```
 
 ### Showing loading content
 Keys on `content` are only defined once a response is received from the API. You can use the `__loading` key to determine if a response is still in flight.

--- a/src/__tests__/injectContent.test.js
+++ b/src/__tests__/injectContent.test.js
@@ -5,6 +5,11 @@ import {injectContent} from '../injectContent';
 import * as reactApollo from 'react-apollo';
 
 const fixtures = {
+  context: {
+    trxCMA: {
+      website: 'banana'
+    }
+  },
   injectedContent: [{
     id: "d2Vic2l0ZTp3ZWxjb21lVGV4dAo=",
     __typename: "TextContent",
@@ -25,6 +30,34 @@ describe('injectContent', () => {
     expect(typeof injectContent).toBe('function')
   })
 
+  it('accepts a string argument and uses apollo graphql to get the slug', () => {
+    const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
+      (query, config) => (WrappedComponent) => (props) =>
+        <WrappedComponent
+          {...props}
+          data={{
+            loading: false,
+            content: [fixtures.injectedContent[0], fixtures.injectedContent[1]]
+          }}
+        />
+    );
+    const fun = jest.fn(props => <div/>);
+    const Component = injectContent('welcome-text')(fun);
+    const mountedComponent = mount(
+      <Component />,
+      {context: fixtures.context}
+    )
+
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][1].options(fixtures.context)).toHaveProperty(
+      'variables.slugs',
+      [{ slug: "welcome-text", website: "banana" }]
+    )
+
+    spy.mockReset();
+    spy.mockRestore();
+  })
+
   it('accepts any number of string arguments and uses apollo graphql to get slugs', () => {
     const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
       (query, config) => (WrappedComponent) => (props) =>
@@ -40,11 +73,11 @@ describe('injectContent', () => {
     const Component = injectContent('welcome-text', "special-offer")(fun);
     const mountedComponent = mount(
       <Component />,
-      {context: {trxCMA: {website: 'banana'}}}
+      {context: fixtures.context}
     )
 
     expect(spy).toHaveBeenCalled();
-    expect(spy.mock.calls[0][1].options({trxCMA: {website: 'banana'}})).toHaveProperty(
+    expect(spy.mock.calls[0][1].options(fixtures.context)).toHaveProperty(
       'variables.slugs',
       [
         {slug: "welcome-text", website: "banana"},
@@ -65,7 +98,7 @@ describe('injectContent', () => {
     const Component = injectContent('welcomeText')(fun);
     const mountedComponent = mount(
       <Component />,
-      {context: {trxCMA: {website: 'banana'}}}
+      {context: fixtures.context}
     );
 
     expect(mountedComponent).toBeDefined()
@@ -91,7 +124,7 @@ describe('injectContent', () => {
     const Component = injectContent('welcome-text', "special-offer")(fun);
     const mountedComponent = mount(
       <Component />,
-      {context: {trxCMA: {website: 'banana'}}}
+      {context: fixtures.context}
     )
 
     expect(mountedComponent).toBeDefined()

--- a/src/__tests__/injectContent.test.js
+++ b/src/__tests__/injectContent.test.js
@@ -41,8 +41,8 @@ describe('injectContent', () => {
           }}
         />
     );
-    const fun = jest.fn(props => <div/>);
-    const Component = injectContent('welcome-text')(fun);
+    const child = jest.fn(props => <div/>);
+    const Component = injectContent('welcome-text')(child);
     const mountedComponent = mount(
       <Component />,
       {context: fixtures.context}
@@ -69,8 +69,8 @@ describe('injectContent', () => {
           }}
         />
     );
-    const fun = jest.fn(props => <div/>);
-    const Component = injectContent('welcome-text', "special-offer")(fun);
+    const child = jest.fn(props => <div/>);
+    const Component = injectContent('welcome-text', "special-offer")(child);
     const mountedComponent = mount(
       <Component />,
       {context: fixtures.context}
@@ -94,16 +94,16 @@ describe('injectContent', () => {
       (query, config) => (WrappedComponent) => (props) =>
         <WrappedComponent {...props} data={{loading: true, content: []}}/>
     )
-    const fun = jest.fn(props => <div/>);
-    const Component = injectContent('welcomeText')(fun);
+    const child = jest.fn(props => <div/>);
+    const Component = injectContent('welcomeText')(child);
     const mountedComponent = mount(
       <Component />,
       {context: fixtures.context}
     );
 
     expect(mountedComponent).toBeDefined()
-    expect(fun).toHaveBeenCalled();
-    expect(fun.mock.calls[0][0].content).toMatchObject({__loading: true});
+    expect(child).toHaveBeenCalled();
+    expect(child.mock.calls[0][0].content).toMatchObject({__loading: true});
 
     spy.mockReset();
     spy.mockRestore();
@@ -120,16 +120,16 @@ describe('injectContent', () => {
           }}
         />
     );
-    const fun = jest.fn(props => <div/>);
-    const Component = injectContent('welcome-text', "special-offer")(fun);
+    const child = jest.fn(props => <div/>);
+    const Component = injectContent('welcome-text', "special-offer")(child);
     const mountedComponent = mount(
       <Component />,
       {context: fixtures.context}
     )
 
     expect(mountedComponent).toBeDefined()
-    expect(fun).toHaveBeenCalled();
-    expect(fun.mock.calls[0][0].content).toMatchObject({
+    expect(child).toHaveBeenCalled();
+    expect(child.mock.calls[0][0].content).toMatchObject({
       __loading: false,
       "welcome-text": "Hi would you like a frozen banana",
       "special-offer": "Free single-dip banana for family members!"
@@ -153,14 +153,13 @@ describe('injectContent', () => {
         />
       }
     );
-    const fun = jest.fn(props => <div/>);
 
+    const child = jest.fn(props => <div/>);
     const slugFunc = jest.fn(props => [
       'welcome-text',
       props.offerAvailable ? 'offer-available' : 'offer-expired'
     ])
-
-    const Component = injectContent(slugFunc)(fun);
+    const Component = injectContent(slugFunc)(child);
     const mountedComponent = mount(
       <Component offerAvailable={false} />,
       {context: fixtures.context}
@@ -177,7 +176,7 @@ describe('injectContent', () => {
         {slug: "offer-expired", website: "banana"}
       ]
     )
-    expect(fun).toHaveBeenCalledWith(expect.objectContaining({
+    expect(child).toHaveBeenCalledWith(expect.objectContaining({
       offerAvailable: false
     }))
 

--- a/src/__tests__/injectContent.test.js
+++ b/src/__tests__/injectContent.test.js
@@ -4,9 +4,56 @@ import {mount} from 'enzyme';
 import {injectContent} from '../injectContent';
 import * as reactApollo from 'react-apollo';
 
+const fixtures = {
+  injectedContent: [{
+    id: "d2Vic2l0ZTp3ZWxjb21lVGV4dAo=",
+    __typename: "TextContent",
+    "website": "banana",
+    "slug": "welcome-text",
+    "text": "Hi would you like a frozen banana"
+  }, {
+    id: "d2Vic2l0ZTp3ZWxjb21lVGV4dAo=",
+    __typename: "TextContent",
+    "website": "banana",
+    "slug": "special-offer",
+    "text": "Free single-dip banana for family members!"
+  }]
+}
+
 describe('injectContent', () => {
   it('is a function', () => {
     expect(typeof injectContent).toBe('function')
+  })
+
+  it('accepts any number of string arguments and uses apollo graphql to get slugs', () => {
+    const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
+      (query, options) => (WrappedComponent) => (props) =>
+        <WrappedComponent
+          {...props}
+          data={{
+            loading: false,
+            content: [fixtures.injectedContent[0], fixtures.injectedContent[1]]
+          }}
+        />
+    );
+    const fun = jest.fn(props => <div/>);
+    const Component = injectContent('welcome-text', "special-offer")(fun);
+    const mountedComponent = mount(
+      <Component />,
+      {context: {trxCMA: {website: 'banana'}}}
+    )
+
+    expect(spy).toHaveBeenCalled();
+    expect(spy.mock.calls[0][1].options({trxCMA: {website: 'banana'}})).toHaveProperty(
+      'variables.slugs',
+      [
+        {slug: "welcome-text", website: "banana"},
+        {slug: "special-offer", website: "banana"}
+      ]
+    )
+
+    spy.mockReset();
+    spy.mockRestore();
   })
 
   it('injects the loading prop from react-apollo', () => {
@@ -36,19 +83,7 @@ describe('injectContent', () => {
           {...props}
           data={{
             loading: false,
-            content: [{
-              id: "d2Vic2l0ZTp3ZWxjb21lVGV4dAo=",
-              __typename: "TextContent",
-              "website": "banana",
-              "slug": "welcome-text",
-              "text": "Hi would you like a frozen banana"
-            }, {
-              id: "d2Vic2l0ZTp3ZWxjb21lVGV4dAo=",
-              __typename: "TextContent",
-              "website": "banana",
-              "slug": "special-offer",
-              "text": "Free single-dip banana for family members!"
-            }]
+            content: [fixtures.injectedContent[0], fixtures.injectedContent[1]]
           }}
         />
     );

--- a/src/__tests__/injectContent.test.js
+++ b/src/__tests__/injectContent.test.js
@@ -177,6 +177,9 @@ describe('injectContent', () => {
         {slug: "offer-expired", website: "banana"}
       ]
     )
+    expect(fun).toHaveBeenCalledWith(expect.objectContaining({
+      offerAvailable: false
+    }))
 
     spy.mockReset();
     spy.mockRestore();

--- a/src/__tests__/injectContent.test.js
+++ b/src/__tests__/injectContent.test.js
@@ -27,7 +27,7 @@ describe('injectContent', () => {
 
   it('accepts any number of string arguments and uses apollo graphql to get slugs', () => {
     const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
-      (query, options) => (WrappedComponent) => (props) =>
+      (query, config) => (WrappedComponent) => (props) =>
         <WrappedComponent
           {...props}
           data={{
@@ -58,7 +58,7 @@ describe('injectContent', () => {
 
   it('injects the loading prop from react-apollo', () => {
     const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
-      (query, options) => (WrappedComponent) => (props) =>
+      (query, config) => (WrappedComponent) => (props) =>
         <WrappedComponent {...props} data={{loading: true, content: []}}/>
     )
     const fun = jest.fn(props => <div/>);
@@ -78,7 +78,7 @@ describe('injectContent', () => {
 
   it('maps returned slugs directly onto the injected content prop', () => {
     const spy = jest.spyOn(reactApollo, 'graphql').mockImplementation(
-      (query, options) => (WrappedComponent) => (props) =>
+      (query, config) => (WrappedComponent) => (props) =>
         <WrappedComponent
           {...props}
           data={{

--- a/src/injectContent.js
+++ b/src/injectContent.js
@@ -33,10 +33,18 @@ export const injectContent = (...args)=>compose(
   getContext({
     trxCMA:PropTypes.object.isRequired
   }),
-  graphql(contentQuery,{
-    options:props=>({
-      variables:hocArgsToVars(props.trxCMA.website,args)
-    })
+  graphql(contentQuery, {
+    options: props => {
+      if (args.length === 1 && typeof args[0] === 'function') {
+        return {
+          variables: hocArgsToVars(props.trxCMA.website, args[0](props))
+        }
+      } else {
+        return {
+          variables: hocArgsToVars(props.trxCMA.website, args)
+        }
+      }
+    }
   }),
   mapProps(props=>{
     const {


### PR DESCRIPTION
You can now provide `injectContent` with a single functional argument.

The function receives props and should return an array of slugs to retrieve.